### PR TITLE
Delete unused `exclude_paths` variable

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,7 +11,6 @@ import subprocess
 
 binstub = "bandit3"
 include_paths = ["."]
-exclude_paths = []
 
 # severity converts the severity of a bandit issue
 # to the severity accepted by CodeClimate


### PR DESCRIPTION
This variable is unused, and it seems unlikely it will be.