### PR TITLE
Tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bandit is a tool designed to find common security issues in Python code.
 
 ```
 git clone https://github.com/noqcks/codeclimate-bandit
-cd codeclimate-hlint
+cd codeclimate-bandit
 make release
 ```
 
@@ -16,7 +16,7 @@ make release
 
 .codeclimate.yml
 ```
-engines:
+plugins:
   bandit:
     enabled: true
     config:


### PR DESCRIPTION
- Fix the `cd` path for build instructions
- Use more modern codeclimate config key: `plugins` is preferred to `engines` these days.